### PR TITLE
ボードの状態管理を追加

### DIFF
--- a/components/CellGame.vue
+++ b/components/CellGame.vue
@@ -117,11 +117,15 @@ export default {
       return x * this.field + y
     },
     clickMark(id) {
+      // 初めてのクリック or どこでもクリックできる状態なら
       if (!this.isStarted || this.isClickAbleAnywhere) {
         this.initGame()
       } else if (
+        // セルゲームが終わっている
         this.isOver ||
+        // すでにマークされている
         this.board[id] !== 0 ||
+        // クリックしたセルID と今クリックできるセルIDが違う
         this.cellId !== this.activeCellId
       ) {
         return
@@ -129,15 +133,24 @@ export default {
 
       this.board[id] = this.player
       this.$forceUpdate()
+      // クリックできるセルIDを更新
       this.updateActiveCellId(id)
+      // セルIDがクリックできる状態か確認
       this.checkCellClickAble(id)
       this.isWinJudge() ? this.gameResult() : this.changePlayer()
     },
     isWinJudge() {
       const sumNums = winIds.map(ids => ids.reduce((x, y) => x + this.board[y], 0))
+      // 引き分けだった時
       if (this.isDrawJudge(this.board)) {
         this.isDraw = true
         this.isOver = true
+        // board.js に引き分けを追加
+        const resultData = {
+          cellId: this.cellId,
+          result: 9
+        }
+        this.updateGameBoard(resultData)
         return
       }
       const isWin = sumNums.some(num => Math.abs(num) === 3)
@@ -149,9 +162,11 @@ export default {
     gameResult() {
       this.winPlayer = this.player
       this.isOver = true
+      
+      // board.js に結果を追加
       const resultData = {
         cellId: this.cellId,
-        player: this.player
+        result: this.player
       }
       this.updateGameBoard(resultData)
     }

--- a/components/CellGame.vue
+++ b/components/CellGame.vue
@@ -54,18 +54,20 @@ export default {
       0, 0, 0,
       0, 0, 0
     ],
-    // player: 1
+    winPlayer: ''
   }),
   computed: {
-    ...mapState('board', ['player']),
+    ...mapState({
+      player: state => state.board.player
+    }),
     result() {
       if (this.isDraw) return '△'
-      return this.player === 1 ? '○' : '✕'
+      return this.winPlayer === 1 ? '○' : '✕'
     },
     resultClasses() {
       if (this.isDraw) return 'tryangle'
-      if (this.player === 1) return 'circle'
-      if (this.player === -1) return 'cross'
+      if (this.winPlayer === 1) return 'circle'
+      if (this.winPlayer === -1) return 'cross'
       return ''
     }
   },
@@ -80,7 +82,7 @@ export default {
       }
       this.board[id] = this.player
       this.$forceUpdate()
-      this.isWinJudge() ? this.isOver = true : this.changePlayer()
+      this.isWinJudge() ? this.gameResult() : this.changePlayer()
     },
     isWinJudge() {
       const sumNums = winIds.map(ids => ids.reduce((x, y) => x + this.board[y], 0))
@@ -95,6 +97,10 @@ export default {
     },
     isDrawJudge(nums) {
       return nums.every(num => num !== 0)
+    },
+    gameResult() {
+      this.winPlayer = this.player
+      this.isOver = true
     }
   }
 }

--- a/components/CellGame.vue
+++ b/components/CellGame.vue
@@ -63,11 +63,12 @@ export default {
       0, 0, 0,
       0, 0, 0
     ],
-    winPlayer: ''
+    winPlayer: null
   }),
   computed: {
     ...mapState({
       isStarted: state => state.board.isStarted,
+      isClickAbleAnywhere: state => state.board.isClickAbleAnywhere,
       player: state => state.board.player,
       activeCellId: state => state.board.activeCellId
     }),
@@ -106,16 +107,18 @@ export default {
   },
   methods: {
     ...mapActions('board', [
-      'gameStart',
+      'initGame',
       'changePlayer',
-      'updateActiveCellId'
+      'updateActiveCellId',
+      'checkCellClickAble',
+      'updateGameBoard'
     ]),
     getId(x, y) {
       return x * this.field + y
     },
     clickMark(id) {
-      if (!this.isStarted) {
-        this.gameStart()
+      if (!this.isStarted || this.isClickAbleAnywhere) {
+        this.initGame()
       } else if (
         this.isOver ||
         this.board[id] !== 0 ||
@@ -123,15 +126,16 @@ export default {
       ) {
         return
       }
-      
-      this.updateActiveCellId(id)
+
       this.board[id] = this.player
       this.$forceUpdate()
+      this.updateActiveCellId(id)
+      this.checkCellClickAble(id)
       this.isWinJudge() ? this.gameResult() : this.changePlayer()
     },
     isWinJudge() {
       const sumNums = winIds.map(ids => ids.reduce((x, y) => x + this.board[y], 0))
-      if (this.isDrawJudge(sumNums)) {
+      if (this.isDrawJudge(this.board)) {
         this.isDraw = true
         this.isOver = true
         return
@@ -145,6 +149,11 @@ export default {
     gameResult() {
       this.winPlayer = this.player
       this.isOver = true
+      const resultData = {
+        cellId: this.cellId,
+        player: this.player
+      }
+      this.updateGameBoard(resultData)
     }
   }
 }
@@ -162,7 +171,7 @@ export default {
   }
   &__result {
     position: absolute;
-    font-size: 16rem;
+    font-size: 15rem;
   }
 }
 

--- a/components/CellGame.vue
+++ b/components/CellGame.vue
@@ -24,6 +24,7 @@
 </template>
 
 <script>
+import { mapState, mapActions } from 'vuex'
 import Square from '~/components/Square'
 
 const winIds = [
@@ -53,9 +54,10 @@ export default {
       0, 0, 0,
       0, 0, 0
     ],
-    player: 1
+    // player: 1
   }),
   computed: {
+    ...mapState('board', ['player']),
     result() {
       if (this.isDraw) return '△'
       return this.player === 1 ? '○' : '✕'
@@ -68,6 +70,7 @@ export default {
     }
   },
   methods: {
+    ...mapActions('board', ['changePlayer']),
     getId(x, y) {
       return x * this.field + y
     },
@@ -77,7 +80,7 @@ export default {
       }
       this.board[id] = this.player
       this.$forceUpdate()
-      this.isWinJudge() ? this.isOver = true : this.player *= -1
+      this.isWinJudge() ? this.isOver = true : this.changePlayer()
     },
     isWinJudge() {
       const sumNums = winIds.map(ids => ids.reduce((x, y) => x + this.board[y], 0))
@@ -87,6 +90,7 @@ export default {
         return
       }
       const isWin = sumNums.some(num => Math.abs(num) === 3)
+      console.log(sumNums)
       return isWin
     },
     isDrawJudge(nums) {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -9,7 +9,7 @@
           v-for="(m, j) in field"
           :key="j"
         >
-          <cell-game />
+          <cell-game :cell-id="getId(i, j)" />
         </td>
       </tr>
     </table>
@@ -25,7 +25,12 @@ export default {
   },
   data:() => ({
     field: 3
-  })
+  }),
+  methods: {
+    getId(x, y) {
+      return x * this.field + y
+    }
+  }
 }
 </script>
 

--- a/store/board.js
+++ b/store/board.js
@@ -1,15 +1,34 @@
 export const state = () => ({
+  isStarted: false,
+  boardState: [
+    0, 0, 0,
+    0, 0, 0,
+    0, 0, 0
+  ],
   player: 1,
+  activeCellId: null
 })
 
 export const mutations = {
+  GAME_START(state) {
+    state.isStarted = true
+  },
   CHANGE_PLAYER(state) {
     state.player *= -1
+  },
+  UPDATE_ACTIVE_CELL_ID(state, id) {
+    state.activeCellId = id
   }
 }
 
 export const actions = {
+  gameStart({ commit }) {
+    commit('GAME_START')
+  },
   changePlayer({ commit }) {
     commit('CHANGE_PLAYER')
+  },
+  updateActiveCellId({ commit }, id) {
+    commit('UPDATE_ACTIVE_CELL_ID', id)
   }
 }

--- a/store/board.js
+++ b/store/board.js
@@ -1,0 +1,15 @@
+export const state = () => ({
+  player: 1,
+})
+
+export const mutations = {
+  CHANGE_PLAYER(state) {
+    state.player *= -1
+  }
+}
+
+export const actions = {
+  changePlayer({ commit }) {
+    commit('CHANGE_PLAYER')
+  }
+}

--- a/store/board.js
+++ b/store/board.js
@@ -28,7 +28,7 @@ export const mutations = {
     }
   },
   UPDATE_GAME_BOARD(state, data) {
-    state.mainBoard[data.cellId] = data.player
+    state.mainBoard[data.cellId] = data.result
   }
 }
 

--- a/store/board.js
+++ b/store/board.js
@@ -1,34 +1,51 @@
 export const state = () => ({
   isStarted: false,
-  boardState: [
+  isClickAbleAnywhere: false,
+  mainBoard: [
     0, 0, 0,
     0, 0, 0,
     0, 0, 0
   ],
   player: 1,
-  activeCellId: null
+  activeCellId: ''
 })
 
 export const mutations = {
-  GAME_START(state) {
+  INIT_GAME(state) {
     state.isStarted = true
+    state.isClickAbleAnywhere = false
   },
   CHANGE_PLAYER(state) {
     state.player *= -1
   },
   UPDATE_ACTIVE_CELL_ID(state, id) {
     state.activeCellId = id
+  },
+  CHECK_CELL_CLICK_ABLE(state, id) {
+    if (state.mainBoard[id] !== 0) {
+      state.isClickAbleAnywhere = true
+      state.activeCellId = ''
+    }
+  },
+  UPDATE_GAME_BOARD(state, data) {
+    state.mainBoard[data.cellId] = data.player
   }
 }
 
 export const actions = {
-  gameStart({ commit }) {
-    commit('GAME_START')
+  initGame({ commit }) {
+    commit('INIT_GAME')
   },
   changePlayer({ commit }) {
     commit('CHANGE_PLAYER')
   },
   updateActiveCellId({ commit }, id) {
     commit('UPDATE_ACTIVE_CELL_ID', id)
+  },
+  checkCellClickAble({ commit }, id) {
+    commit('CHECK_CELL_CLICK_ABLE', id)
+  },
+  updateGameBoard({ commit }, data) {
+    commit('UPDATE_GAME_BOARD', data)
   }
 }


### PR DESCRIPTION

refs #5 

#### Vuex で全体のボードの状態管理を司る `board.js` を作成
- 管理する項目
  - メインボードの状態 => `mainBoard`
  - 今のプレイヤー => `player`
  - ボードのどこでもクリックできる状態か => `isClickAbleAnywhere`
  - クリックできるセル ID => `activeCellId`

#### プレイヤーチェンジとクリックできるセルを有効化
- マークする毎に `board.js` の `player` を切り替える
- マークしたセル ID を `activeCellId` にコミット
- マーク毎に `activeCellId` と マークしたセルID を比較して一致したらマークできる
- `activeCellId` をわかりやすいように可視化

#### セルゲームが終わった時に結果 と 全体をクリックできる Boolean を追加
- セルゲーム終了時に、`mainBoard` に結果を追加
- `activeCellId` がすでにゲーム終了のセルだった場合、`isClickAbleAnywhere` を有効にして
全体のセルをクリックできるようにした


![Untitled](https://user-images.githubusercontent.com/45064837/70073093-96605a80-163b-11ea-99b2-287160a7f29f.gif)