### PR TITLE
ゲームの結果を表示させる

### DIFF
--- a/assets/basic.scss
+++ b/assets/basic.scss
@@ -14,19 +14,7 @@ table {
 }
 
 td {
-  border: .3rem solid #000;
+  border: .3rem solid #333;
   text-align: center;
   user-select: none;
-}
-
-.circle {
-  color: #f00;
-}
-
-.cross {
-  color: #00f;
-}
-
-.tryangle {
-  color: #0f0
 }

--- a/assets/game.js
+++ b/assets/game.js
@@ -1,0 +1,42 @@
+/**
+ * 判定ライン
+ * @type {Array}
+ */
+const winIds = [
+  // vertical
+  [0, 3, 6],
+  [1, 4, 7],
+  [2, 5, 8],
+  // horizontal
+  [0, 1, 2],
+  [3, 4, 5],
+  [6, 7, 8],
+  // diagonal
+  [0, 4, 8],
+  [2, 4, 6]
+]
+
+/**
+ * 勝ち判定をする関数
+ * @param {Array} data ボードの状態
+ * @return {Boolean}
+ */
+const isWinJudge = data => {
+  const sumNums = winIds.map(ids => ids.reduce((x, y) => x + data[y], 0))
+  return sumNums.some(num => Math.abs(num) === 3)
+}
+
+/**
+ * 引き分けを判定する関数
+ * @param {Array} data ボードの状態
+ * @return {Boolean}
+ */
+const isDrawJudge = data => {
+  return data.every(x => x !== 0)
+}
+
+
+export {
+  isWinJudge,
+  isDrawJudge
+}

--- a/components/CellGame.vue
+++ b/components/CellGame.vue
@@ -8,7 +8,7 @@
       class="cell_game__result"
       :class="resultClasses"
     >
-      {{ result }}
+      {{ cellGameResult }}
     </div>
     <table frame="void">
       <tr
@@ -64,34 +64,22 @@ export default {
     isActive() {
       return this.cellId === this.activeCellId
     },
-    result() {
-      if (this.isDraw) return '△'
-      return this.winPlayer === 1 ? '○' : '✕'
+    cellGameResult() {
+      return this.isDraw ? '△' :
+             this.winPlayer === 1 ? '○' :
+             this.winPlayer === -1 ? '✕' :
+             ''
     },
     resultClasses() {
-      if (this.isDraw) {
-        return 'tryangle'
-      }
-      if (this.winPlayer === 1) {
-        return 'circle'
-      }
-      if (this.winPlayer === -1) {
-        return 'cross'
-      }
-      return ''
+      return this.isDraw ? 'tryangle' :
+             this.winPlayer === 1 ? 'circle' :
+             this.winPlayer === -1 ? 'cross' :
+             ''
     },
     activeClasses() {
-      if (this.player === 1) {
-        return {
-        'active--circle': this.isActive
-        }
-      }
-      if (this.player === -1) {
-        return {
-          'active--cross': this.isActive
-        }
-      }
-      return ''
+      return this.player === 1 ? {'active--circle': this.isActive} :
+             this.player === -1 ? {'active--cross': this.isActive} :
+             ''
     }
   },
   methods: {
@@ -128,17 +116,17 @@ export default {
       this.board[id] = this.player
       this.$forceUpdate()
 
-      // クリックできるセルIDを更新
-      this.updateActiveCellId(id)
-      // セルIDがクリックできる状態か確認
-      this.checkCellClickAble(id)
-
       // 引き分け判定
       this.drawJudge()
       // 勝敗判定
       if (isWinJudge(this.board)) {
-        this.cellGameResult()
+        this.cellGameJudgment()
       }
+
+      // クリックできるセルIDを更新
+      this.updateActiveCellId(id)
+      // セルIDがクリックできる状態か確認
+      this.checkCellClickAble(id)
 
       // プレイヤーをチェンジ
       this.changePlayer()
@@ -156,7 +144,7 @@ export default {
         this.ultimateJudgment()
       }
     },
-    cellGameResult() {
+    cellGameJudgment() {
       this.winPlayer = this.player
       this.isOver = true
       
@@ -202,17 +190,30 @@ export default {
 }
 
 td {
-  border: .1rem solid #000;
+  border: .1rem solid #333;
   height: 5rem;
   width: 5rem;
   font-size: 3rem;
 }
 
+.circle {
+  color: #ee0011;
+}
+
+.cross {
+  color: #0010ed;
+}
+
+.tryangle {
+  color: #10ed00;
+}
+
 .active--circle {
-  background-color: #ffbfcb;
+  background-color: rgba(238, 0, 17, .2);
 }
 
 .active--cross {
-  background-color: #bffff3;
+  background-color: rgba(0, 17, 238, .2);
 }
+
 </style>

--- a/components/CellGame.vue
+++ b/components/CellGame.vue
@@ -28,21 +28,8 @@
 
 <script>
 import { mapState, mapActions } from 'vuex'
+import { isWinJudge, isDrawJudge } from '~/assets/game'
 import Square from '~/components/Square'
-
-const winIds = [
-  // vertical
-  [0, 3, 6],
-  [1, 4, 7],
-  [2, 5, 8],
-  // horizontal
-  [0, 1, 2],
-  [3, 4, 5],
-  [6, 7, 8],
-  // diagonal
-  [0, 4, 8],
-  [2, 4, 6]
-]
 
 export default {
   components: {
@@ -141,28 +128,23 @@ export default {
       this.board[id] = this.player
       this.$forceUpdate()
 
-
-      // 引き分け判定
-      this.drawJudge(this.board)
-      // 勝敗判定
-      if (this.isWinJudge()) {
-        this.cellGameResult()
-      }
-
-      this.changePlayer()
       // クリックできるセルIDを更新
       this.updateActiveCellId(id)
       // セルIDがクリックできる状態か確認
       this.checkCellClickAble(id)
+
+      // 引き分け判定
+      this.drawJudge()
+      // 勝敗判定
+      if (isWinJudge(this.board)) {
+        this.cellGameResult()
+      }
+
+      // プレイヤーをチェンジ
+      this.changePlayer()
     },
-    isWinJudge() {
-      const sumNums = winIds.map(ids => ids.reduce((x, y) => x + this.board[y], 0))
-      const isWin = sumNums.some(num => Math.abs(num) === 3)
-      return isWin
-    },
-    drawJudge(nums) {
-      const isDraw = nums.every(num => num !== 0)
-      if (this.isDraw) {
+    drawJudge() {
+      if (isDrawJudge(this.board)) {
         this.isDraw = true
         this.isOver = true
         // board.js に引き分けを追加
@@ -171,7 +153,7 @@ export default {
           result: 9
         }
         this.updateMainBoard(resultData)
-        this.ultimateJudge()
+        this.ultimateJudgment()
       }
     },
     cellGameResult() {
@@ -184,21 +166,19 @@ export default {
         result: this.player
       }
       this.updateMainBoard(resultData)
-      this.ultimateJudge()
+      this.ultimateJudgment()
     },
     // 最終判定
-    ultimateJudge() {
+    ultimateJudgment() {
       // 引き分け時
-      const isDraw = this.mainBoard.every(num => num !== 0)
-      if (isDraw) {
+      if (isDrawJudge(this.mainBoard)) {
         console.log('drawです！')
       }
 
       // 勝敗判定
-      const sumNums = winIds.map(ids => ids.reduce((x, y) => x + this.mainBoard[y], 0))
-      const isWin = sumNums.some(num => Math.abs(num) === 3)
-      if (isWin) {
+      if (isWinJudge(this.mainBoard)) {
         this.gameOver(this.player)
+        console.log('Game Over')
       }
     }
   }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,10 +13,17 @@
         </td>
       </tr>
     </table>
+    <p
+      v-if="isGameOver"
+      class="result"
+    >
+      {{ result }}
+    </p>
   </div>
 </template>
 
 <script>
+import { mapState } from 'vuex'
 import CellGame from '~/components/CellGame'
 
 export default {
@@ -26,6 +33,15 @@ export default {
   data:() => ({
     field: 3
   }),
+  computed: {
+    ...mapState({
+      isGameOver: state => state.board.isGameOver,
+      gameWinner: state => state.board.gameWinner
+    }),
+    result() {
+      return `${this.gameWinner}の勝ち`
+    }
+  },
   methods: {
     getId(x, y) {
       return x * this.field + y

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,6 +1,9 @@
 <template>
-  <div class="game__container">
-    <table frame="void">
+  <div class="ultimate_game__container">
+    <table
+      :class="{'ultimate_game--over': isGameOver}"
+      frame="void"
+    >
       <tr
         v-for="(n, i) in field"
         :key="i"
@@ -13,12 +16,15 @@
         </td>
       </tr>
     </table>
-    <p
+    <div
       v-if="isGameOver"
-      class="result"
+      class="ultimate_game__result__container"
+      :class="resultClasses"
     >
-      {{ result }}
-    </p>
+      <p class="ultimate_game__result">
+        {{ gameResult }}
+      </p>
+    </div>
   </div>
 </template>
 
@@ -36,10 +42,20 @@ export default {
   computed: {
     ...mapState({
       isGameOver: state => state.board.isGameOver,
+      isGameDraw: state => state.board.isGameDraw,
       gameWinner: state => state.board.gameWinner
     }),
-    result() {
-      return `${this.gameWinner}の勝ち`
+    gameResult() {
+      return !this.gameWinner ? '引き分け' :
+             this.gameWinner === 1 ? ' ◯ の勝ち' :
+             this.gameWinner === -1 ? ' ✕ の勝ち' :
+             ''
+    },
+    resultClasses() {
+      return !this.gameWinner ? {'result--draw': this.isGameOver} :
+             this.gameWinner === 1 ? {'result--circle': this.isGameOver} :
+             this.gameWinner === -1 ? {'result--cross': this.isGameOver} :
+             ''
     }
   },
   methods: {
@@ -51,4 +67,42 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.ultimate_game {
+  &__container {
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  &__result__container {
+    position: absolute;
+    width: 100rem;
+    text-align: center;
+  }
+
+  &__result {
+    font-size: 10rem;
+  }
+
+  &--over {
+    opacity: .3;
+  }
+}
+
+.result--draw {
+  color: #fafafa;
+  background-color: #999;
+}
+
+.result--circle {
+  color: #ee0011;
+  background-color: rgba(238, 0, 17, .2);
+}
+
+.result--cross {
+  color: #0010ed;
+  background-color: rgba(0, 17, 238, .2);
+}
+
 </style>

--- a/store/board.js
+++ b/store/board.js
@@ -24,7 +24,7 @@ export const mutations = {
     state.activeCellId = id
   },
   CHECK_CELL_CLICK_ABLE(state, id) {
-    if (state.mainBoard[id] !== 0) {
+    if (state.mainBoard[id] !== 0 || state.isGameOver) {
       state.isClickAbleAnywhere = true
       state.activeCellId = ''
     }
@@ -34,7 +34,6 @@ export const mutations = {
   },
   GAME_OVER(state, player) {
     state.isGameOver = true
-    state.activeCellId = ''
     state.gameWinner = player
   }
 }

--- a/store/board.js
+++ b/store/board.js
@@ -3,7 +3,7 @@ export const state = () => ({
   isGameOver: false,
   isClickAbleAnywhere: false,
   mainBoard: [
-    0, 1, 1,
+    0, 0, 0,
     0, 0, 0,
     0, 0, 0
   ],

--- a/store/board.js
+++ b/store/board.js
@@ -34,6 +34,7 @@ export const mutations = {
   },
   GAME_OVER(state, player) {
     state.isGameOver = true
+    state.activeCellId = ''
     state.gameWinner = player
   }
 }

--- a/store/board.js
+++ b/store/board.js
@@ -1,13 +1,15 @@
 export const state = () => ({
   isStarted: false,
+  isGameOver: false,
   isClickAbleAnywhere: false,
   mainBoard: [
-    0, 0, 0,
+    0, 1, 1,
     0, 0, 0,
     0, 0, 0
   ],
   player: 1,
-  activeCellId: ''
+  activeCellId: '',
+  gameWinner: ''
 })
 
 export const mutations = {
@@ -27,8 +29,12 @@ export const mutations = {
       state.activeCellId = ''
     }
   },
-  UPDATE_GAME_BOARD(state, data) {
+  UPDATE_MAIN_BOARD(state, data) {
     state.mainBoard[data.cellId] = data.result
+  },
+  GAME_OVER(state, player) {
+    state.isGameOver = true
+    state.gameWinner = player
   }
 }
 
@@ -45,7 +51,10 @@ export const actions = {
   checkCellClickAble({ commit }, id) {
     commit('CHECK_CELL_CLICK_ABLE', id)
   },
-  updateGameBoard({ commit }, data) {
-    commit('UPDATE_GAME_BOARD', data)
+  updateMainBoard({ commit }, data) {
+    commit('UPDATE_MAIN_BOARD', data)
+  },
+  gameOver({ commit }, player) {
+    commit('GAME_OVER', player)
   }
 }


### PR DESCRIPTION
refs #7 

#### ゲームが終了した時に、結果を盤面上に表示する
- セルゲームの結果が `board.js` にコミットされたとき、全体のボード状態から判定を行う

判定する関数（勝ち判定 ＆ 引き分け判定）を `game.js` として分離し、`assets`フォルダに置いた